### PR TITLE
Allow longer strings when emitting errors, truncate at 1000 vs 60.

### DIFF
--- a/testharness.js
+++ b/testharness.js
@@ -826,7 +826,7 @@ policies and contribution forms [3].
         /* falls through */
         default:
             try {
-                return typeof val + ' "' + truncate(String(val), 60) + '"';
+                return typeof val + ' "' + truncate(String(val), 1000) + '"';
             } catch(e) {
                 return ("[stringifying object threw " + String(e) +
                         " with type " + String(typeof e) + "]");


### PR DESCRIPTION
format_value truncates strings for readability, but was too aggressive. More recent APIs implementation emit useful error messages, e.g. Web Bluetooth may emit a message such as:

SyntaxError: Failed to execute 'getCharacteristic' on 'BluetoothGATTService': Invalid Characteristic name: 'heart_rate'. It must be a valid UUID alias (e.g. 0x1234), UUID (lowercase hex characters e.g. '00001234-0000-1000-8000-00805f9b34fb'), or recognized standard name from https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicsHome.aspx e.g. 'aerobic_heart_rate_lower_limit'.

At least 110 characters are necessary to understand the reason a test is failing. The truncation shouldn't make tests hard to understand or diagnose. A well formed and performing test will not emit long strings, so this is primarily for diagnosing when something isn't working.

Removing truncation may result in very large objects still completely spamming the output. Thus, increasing to 1000, as an order of magnitude larger than what is known to be useful seems an appropriate solution.
